### PR TITLE
Send notification messages to kodi

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ This can also execute scripts in Kodi.
 
 You only need to find out what the script/plugin path is, and what parameter to give.
 
+### Show Toasts
+You can use GUI.ShowNotification to show toast messages on a Kodi player.
+
+Example rule:
+```
+when: doorbell reports present
+then: show Toast "Doorbell" on kodiplayer and pause kodiplayer
+```
+
 
 ### Note's
 Big thanks to the code of Pimatic.

--- a/README.md
+++ b/README.md
@@ -68,16 +68,18 @@ You only need to find out what the script/plugin path is, and what parameter to 
 ### Show Toasts
 You can use GUI.ShowNotification to show toast messages on a Kodi player.
 
-Example rule:
+Example rules:
 ```
 when: doorbell reports present
 then: show Toast "Doorbell" on kodiplayer and pause kodiplayer
 
-when: ...
 then: show Toast "Some Notification" with icon "error" on kodiplayer
 
-when: ...
 then: show Toast "You have been informated" with icon "http://url.to/some_icon.png" on kodiplayer
+
+then: show Toast "Short notice" with icon "info" for 1 second on kodiplayer
+
+then: show Toast "Long notice" for 10 seconds on kodiplayer
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Example rule:
 ```
 when: doorbell reports present
 then: show Toast "Doorbell" on kodiplayer and pause kodiplayer
+
+when: ...
+then: show Toast "Some Notification" with icon "error" on kodiplayer
+
+when: ...
+then: show Toast "You have been informated" with icon "http://url.to/some_icon.png" on kodiplayer
 ```
 
 

--- a/kodi-plugin-config-schema.coffee
+++ b/kodi-plugin-config-schema.coffee
@@ -12,6 +12,10 @@ module.exports = {
       description: "The port for Kodi/XMBC RPC (Default: 9090)"
       type: "integer"
       default: 9090
+    debug:
+      description: "Log information for debugging, including received messages"
+      type: "boolean"
+      default: true
     customOpenCommands:
       description: "Custom Player.Open commands"
       type: "array"

--- a/kodi-plugin.coffee
+++ b/kodi-plugin.coffee
@@ -159,7 +159,7 @@ module.exports = (env) ->
         connection.Player.GetActivePlayers().then (players) =>
           if players.length > 0
             connection.Player.Stop({"playerid":players[0].playerid})
-    previous: () -
+    previous: () ->
       @_connectionProvider.getConnection().then (connection) =>
         connection.Player.GetActivePlayers().then (players) =>
           if players.length > 0

--- a/kodi-plugin.coffee
+++ b/kodi-plugin.coffee
@@ -143,6 +143,9 @@ module.exports = (env) ->
 
       super()
 
+    destroy: () ->
+      super()
+
     getType: () -> Promise.resolve(@_type)
     play: () ->
       @_connectionProvider.getConnection().then (connection) =>


### PR DESCRIPTION
Implement support for notifications. Pimatic can be used to send notifications to Kodi players. For example, when the doorbell rings, pause Kodi and show a notification why it was paused, "Someone at the door".